### PR TITLE
Fixing a bug with user names

### DIFF
--- a/public/js/avatar.js
+++ b/public/js/avatar.js
@@ -43,6 +43,9 @@ window.onload = () => {
 
 style.addEventListener('input', updateAvatar);
 bgColor.addEventListener('input', updateAvatar);
-//playerName.addEventListener('change', updateAvatar);
 randomizeBtn.addEventListener('click', () => updateAvatar(generateRandomSeed()));
+playerName.addEventListener('change', () => {
+    my.name = playerName.value;
+    localStorage.setItem('name', playerName.value);
+});
 


### PR DESCRIPTION
If the user doesn't click randomize, then the name that was filled in from local storage is the one being used, because we weren't storing it.